### PR TITLE
ENH: Better handling for (too) few RTs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,12 +2,14 @@
 Changelog
 =========
 ****************
-v0.6, 2015-xx-xx
+v0.6, 2016-xx-xx
 ****************
 - Replace `onset_delay` parameter of `hardware` components with
   `trigger_time`.
 - Add gustometer support.
 - MultiIndex support in `racemodel.get_percentiles_from_cdf()`
+- Better handling for (too) few response times supplied to
+  `racemodel.gen_cdf()`.
 - Switch to Travis-CI container-based infrastructure.
 - Fix readthedocs.org documentation creation.
 

--- a/pphelper/racemodel.py
+++ b/pphelper/racemodel.py
@@ -120,6 +120,14 @@ def gen_cdf(rts, t_max=None):
     rt_min = rts_unique.min()
     rt_max = rts_unique.max()
 
+    if len(rts_unique) == 1:
+        raise ValueError('Only one unique RT in this dataset! Cannot '
+                         'calculate CDF.')
+
+    if len(rts_unique) < 10:
+        warnings.warn('Found only %i unique RTs in dataset. Please check if '
+                      'this is really what you want.' % len(rts_unique))
+
     # We now calculate the midpoints of the initial plotting positions
     # to use as _new_ plotting positions.
     #

--- a/pphelper/tests/test_racemodel.py
+++ b/pphelper/tests/test_racemodel.py
@@ -3,11 +3,12 @@
 from __future__ import division
 import numpy as np
 import pandas as pd
+import warnings
 
-from pphelper.racemodel import gen_step_fun, gen_cdf,\
-                               gen_percentiles, get_percentiles_from_cdf,\
-                               gen_cdfs_from_list, sum_cdfs, \
-                               gen_cdfs_from_dataframe
+from pphelper.racemodel import (gen_step_fun, gen_cdf,
+                                gen_percentiles, get_percentiles_from_cdf,
+                                gen_cdfs_from_list, sum_cdfs,
+                                gen_cdfs_from_dataframe)
 
 
 def test_gen_step_fun_ordered():
@@ -435,10 +436,32 @@ def test_gen_cdf_negative_rt():
                       254, 256, 259, 270, -5, 280])
 
     result_expected = gen_cdf(rt_a)
-    result = gen_cdf(rt_b)
+    with warnings.catch_warnings(record=True) as w:
+        result = gen_cdf(rt_b)
+        assert w
 
     assert result.equals(result_expected)
     assert result.index.equals(result_expected.index)
+
+
+def test_gen_cdf_only_one_rt():
+    rt = np.array([100])
+
+    try:
+        gen_cdf(rt)
+        did_raise = False
+    except ValueError:
+        did_raise = True
+
+    assert did_raise
+
+
+def test_gen_cdf_less_than_10_rts():
+    rt = np.array([100, 200, 300, 400])
+
+    with warnings.catch_warnings(record=True) as w:
+        gen_cdf(rt)
+        assert w
 
 
 def test_gen_percentiles():


### PR DESCRIPTION
Better handling for (too) few response times supplied to  `racemodel.gen_cdf()`.
Throws warnings for <10 RTs, and raises for only one unique RT.